### PR TITLE
add tags to pipeline

### DIFF
--- a/pipeline.config.yml
+++ b/pipeline.config.yml
@@ -1,4 +1,3 @@
-
 Tags:
   Customer: Source Allies Internal
   Name: event-source-blog


### PR DESCRIPTION
To track ownership of pipelines, we're adding tags to all of them. 